### PR TITLE
Add show parameter to ShellExecuteEx

### DIFF
--- a/VirtualKD-Redux/Host/vmmon/MainDlg.cpp
+++ b/VirtualKD-Redux/Host/vmmon/MainDlg.cpp
@@ -960,6 +960,7 @@ void CMainDlg::RunDebugger(unsigned entryIndex)
             exInfo.lpVerb = L"open";
             exInfo.lpFile = L"WindbgX.exe";
             exInfo.lpParameters = tszCmdLine;
+            exInfo.nShow = SW_SHOWMAXIMIZED;
             if (ShellExecuteExW(&exInfo) == TRUE)
             {
                 proc.idDebuggerProcess = GetProcessId(exInfo.hProcess);


### PR DESCRIPTION
Hi, I just installed yesterday's release on my Windows 10 with all updates.

The problem I'm facing is WinDbgX, automatically detected, is launched but the windows nor the taskbar button appears.

I realized the process was running but, for some reason, hidden. Surprisingly, when I press Alt+TAB to switch windows, it does appear in the list and, when selected, WinDbgX main window appears.

Debugging vmmon64, I forced the `nShow` parameter to `SW_SHOWMAXIMIZED` and the problem disappears.

Thanks for keeping VirtualKD alive.